### PR TITLE
DEVOPS-2673 pass replica count to allow service shutdown

### DIFF
--- a/charts/permissionless-nodes/charts/synchronizer/values.yaml
+++ b/charts/permissionless-nodes/charts/synchronizer/values.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 genesis: validium-bali-04-genesis.json
 
+replicaCount: 1
+
 image:
   repository: hermeznetwork/zkevm-node
   pullPolicy: IfNotPresent

--- a/charts/permissionless-nodes/nodes/api3-oev-network.yaml
+++ b/charts/permissionless-nodes/nodes/api3-oev-network.yaml
@@ -21,14 +21,17 @@ rpc:
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.6"
+  replicaCount: 3
 
 synchronizer:
   genesis: api3.genesis.json
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.6"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v4.0.19"
+  replicaCount: 3

--- a/charts/permissionless-nodes/nodes/astar-cardona.yaml
+++ b/charts/permissionless-nodes/nodes/astar-cardona.yaml
@@ -21,14 +21,17 @@ rpc:
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.3"
+  replicaCount: 3
 
 synchronizer:
   genesis: astar-cardona.genesis.json
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.3"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v4.0.19"
+  replicaCount: 3

--- a/charts/permissionless-nodes/nodes/astar-mainnet.yaml
+++ b/charts/permissionless-nodes/nodes/astar-mainnet.yaml
@@ -21,14 +21,17 @@ rpc:
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.3"
+  replicaCount: 3
 
 synchronizer:
   genesis: astar-mainnet.genesis.json
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.3"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v4.0.19"
+  replicaCount: 3

--- a/charts/permissionless-nodes/nodes/pless-rpc-bali-astar-04.yaml
+++ b/charts/permissionless-nodes/nodes/pless-rpc-bali-astar-04.yaml
@@ -21,14 +21,17 @@ rpc:
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.6"
+  replicaCount: 3
 
 synchronizer:
   genesis: validium-bali-04-genesis.json
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.6"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v5.0.7"
+  replicaCount: 3

--- a/charts/permissionless-nodes/nodes/xchain-testnet.yaml
+++ b/charts/permissionless-nodes/nodes/xchain-testnet.yaml
@@ -21,14 +21,17 @@ rpc:
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.6"
+  replicaCount: 3
 
 synchronizer:
   genesis: xchain-testnet.genesis.json
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.5.13-cdk.6"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v4.0.19"
+  replicaCount: 3

--- a/charts/permissionless-nodes/nodes/xlayer-cardona.yaml
+++ b/charts/permissionless-nodes/nodes/xlayer-cardona.yaml
@@ -21,14 +21,17 @@ rpc:
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.6.4-cdk.2"
+  replicaCount: 3
 
 synchronizer:
   genesis: xlayer-cardona.genesis.json
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.6.4-cdk.2"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v6.0.0"
+  replicaCount: 3

--- a/charts/permissionless-nodes/nodes/xlayer-mainnet.yaml
+++ b/charts/permissionless-nodes/nodes/xlayer-mainnet.yaml
@@ -21,14 +21,17 @@ rpc:
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.6.4-cdk.2"
+  replicaCount: 3
 
 synchronizer:
   genesis: xlayer-mainnet.genesis.json
   image:
     repository: 0xpolygon/cdk-validium-node
     tag: "0.6.4-cdk.2"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v6.0.0"
+  replicaCount: 3

--- a/charts/permissionless-nodes/values.yaml
+++ b/charts/permissionless-nodes/values.yaml
@@ -21,17 +21,20 @@ rpc:
   image:
     repository: hermeznetwork/zkevm-node
     tag: "v0.6.1"
+  replicaCount: 3
 
 synchronizer:
   genesis: validium-bali-04-genesis.json
   image:
     repository: hermeznetwork/zkevm-node
     tag: "v0.6.1"
+  replicaCount: 1
 
 executor:
   image:
     repository: hermeznetwork/zkevm-prover
     tag: "v5.0.7"
+  replicaCount: 3
 
 postgresql:
   enabled: true


### PR DESCRIPTION
Adds `replicaCount` parameter to `values.yaml` to allow shutting down services by setting `replicaCount: 0`

This can be used to pause a service without deleting the infrastructure or services associated with it.