### PR TITLE
DEVOPS-2673 add 1Password param for ForkIDChunkSize

### DIFF
--- a/charts/permissionless-nodes/Chart.yaml
+++ b/charts/permissionless-nodes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/charts/executor/Chart.yaml
+++ b/charts/permissionless-nodes/charts/executor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/charts/rpc/Chart.yaml
+++ b/charts/permissionless-nodes/charts/rpc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/charts/rpc/config/config.toml
+++ b/charts/permissionless-nodes/charts/rpc/config/config.toml
@@ -1,6 +1,7 @@
 {{- $dbPassword := "password" }}
 {{- $rpcUrl := "" }}
 {{- $trustedSequencer := "" }}
+{{- $forkIdChunkSize := 20000 }}
 {{- $opSecrets := (lookup "v1" "Secret" .Release.Namespace "op-secrets") }}
 {{- if $opSecrets.data }}
     {{- if (index $opSecrets.data "dbPlessPassword") }}
@@ -11,6 +12,9 @@
     {{- end }}
     {{- if (index $opSecrets.data "trustedSequencer") }}
         {{- $trustedSequencer = index $opSecrets.data "trustedSequencer" | b64dec }}
+    {{- end }}
+    {{- if (index $opSecrets.data "forkIdChunkSize") }}
+        {{- $forkIdChunkSize = index $opSecrets.data "forkIdChunkSize" | b64dec }}
     {{- end }}
 {{- end }}
 
@@ -81,7 +85,7 @@ MaxConns = 200
 
 [Etherman]
 URL = {{ $rpcUrl | quote }}
-ForkIDChunkSize = 20000
+ForkIDChunkSize = {{ $forkIdChunkSize }}
 MultiGasProvider = false
 [Etherscan]
 ApiKey = ""

--- a/charts/permissionless-nodes/charts/synchronizer/Chart.yaml
+++ b/charts/permissionless-nodes/charts/synchronizer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/charts/synchronizer/config/config.toml
+++ b/charts/permissionless-nodes/charts/synchronizer/config/config.toml
@@ -1,6 +1,7 @@
 {{- $dbPassword := "password" }}
 {{- $rpcUrl := "" }}
 {{- $trustedSequencer := "" }}
+{{- $forkIdChunkSize := 20000 }}
 {{- $opSecrets := (lookup "v1" "Secret" .Release.Namespace "op-secrets") }}
 {{- if $opSecrets.data }}
     {{- if (index $opSecrets.data "dbPlessPassword") }}
@@ -11,6 +12,9 @@
     {{- end }}
     {{- if (index $opSecrets.data "trustedSequencer") }}
         {{- $trustedSequencer = index $opSecrets.data "trustedSequencer" | b64dec }}
+    {{- end }}
+    {{- if (index $opSecrets.data "forkIdChunkSize") }}
+        {{- $forkIdChunkSize = index $opSecrets.data "forkIdChunkSize" | b64dec }}
     {{- end }}
 {{- end }}
 
@@ -81,7 +85,7 @@ MaxConns = 200
 
 [Etherman]
 URL = {{ $rpcUrl | quote }}
-ForkIDChunkSize = 20000
+ForkIDChunkSize = {{ $forkIdChunkSize }}
 MultiGasProvider = false
 [Etherscan]
 ApiKey = ""


### PR DESCRIPTION
## Describe your changes
Adds support for `ForkIDChunkSize` parameter. If this parameter is specified in the 1Password vault, its value will replace the default value of `20000`

## Jira ticket number and link
DEVOPS-2673

## Requirements

Mark the steps below as completed or `N/A` if not applicable. Leave blank if unsure or not done.

- [x] Version bumped in `Chart.yaml` for affected charts
- [ ] `README.md` has been updated or added to reflect the changes in this PR
- [x] I will delete my branch after merging my PR to maintain good repo hygiene
