### PR TITLE
DEVOPS-2673 enable postgres metrics and DD prometheus scraping

### DIFF
--- a/charts/permissionless-nodes/Chart.yaml
+++ b/charts/permissionless-nodes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/values.yaml
+++ b/charts/permissionless-nodes/values.yaml
@@ -68,6 +68,8 @@ postgresql:
         secretKeys:
           adminPasswordKey: "dbAdminPassword"
           userPasswordKey: "dbPlessPassword"
+  metrics:
+    enabled: true
   primary:
     extendedConfiguration: |
       max_connections = 500

--- a/deployments/datadog/datadog-values.yaml
+++ b/deployments/datadog/datadog-values.yaml
@@ -811,9 +811,9 @@ datadog:
   ## ref: https://docs.datadoghq.com/agent/kubernetes/prometheus/
   prometheusScrape:
     # datadog.prometheusScrape.enabled -- Enable autodiscovering pods and services exposing prometheus metrics.
-    enabled: false
+    enabled: true
     # datadog.prometheusScrape.serviceEndpoints -- Enable generating dedicated checks for service endpoints.
-    serviceEndpoints: false
+    serviceEndpoints: true
     # datadog.prometheusScrape.additionalConfigs -- Allows adding advanced openmetrics check configurations with custom discovery rules. (Requires Agent version 7.27+)
     additionalConfigs: []
       # -


### PR DESCRIPTION
## Describe your changes
This update enables datadog to scrape any prometheus endpoint on any k8s that exposes a prometheus endpoint. It also enables the postgres prometheus endpoint. 

## Jira ticket number and link
DEVOPS-2673

## Requirements

Mark the steps below as completed or `N/A` if not applicable. Leave blank if unsure or not done.

- [x] Version bumped in `Chart.yaml` for affected charts
- [ ] `README.md` has been updated or added to reflect the changes in this PR
- [x] I will delete my branch after merging my PR to maintain good repo hygiene
