### PR TITLE
DEVOPS-2809 default to disabled wal metrics

### DIFF
--- a/charts/permissionless-nodes/Chart.yaml
+++ b/charts/permissionless-nodes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/values.yaml
+++ b/charts/permissionless-nodes/values.yaml
@@ -7,6 +7,7 @@ global:
   role: permissionless-node
   team: cdk
   p_service: cdk
+  partner: polygon
   tag: v3
   # 1Password vault config
   vault: cdk-dev
@@ -70,6 +71,8 @@ postgresql:
           userPasswordKey: "dbPlessPassword"
   metrics:
     enabled: true
+    collectors:
+      wal: false
   primary:
     extendedConfiguration: |
       max_connections = 500


### PR DESCRIPTION
## Describe your changes
Sets wal metric collection to `disabled`. Replication is not enabled, soo no metrics to collect. This prevents metrics collection errors in the logs

## Jira ticket number and link
DEVOPS-2809

## Requirements

Mark the steps below as completed or `N/A` if not applicable. Leave blank if unsure or not done.

- [x] Version bumped in `Chart.yaml` for affected charts
- [ ] `README.md` has been updated or added to reflect the changes in this PR
- [x] I will delete my branch after merging my PR to maintain good repo hygiene
