### PR TITLE
SPEC-28 expose metrics endpoint via ingress controller

### DIFF
--- a/charts/agglayer/Chart.yaml
+++ b/charts/agglayer/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.2"
+appVersion: "0.1.3"

--- a/charts/agglayer/templates/deployment.yaml
+++ b/charts/agglayer/templates/deployment.yaml
@@ -63,12 +63,8 @@ spec:
             - "--cfg"
             - "/etc/agglayer/config.toml"
           ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
-              protocol: TCP
-            - name: metrics
-              containerPort: 2223
-              protocol: TCP
+            - containerPort: {{ .Values.service.port }}
+            - containerPort: 2223
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/agglayer/templates/ingress.yaml
+++ b/charts/agglayer/templates/ingress.yaml
@@ -10,7 +10,18 @@ metadata:
   annotations:
     networking.gke.io/managed-certificates: managed-cert
     ingressClassName: "gce"
+    ingress.kubernetes.io/healthcheck-path: "/metrics"
 spec:
+  rules:
+    - http:
+        paths:
+          - path: /metrics
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "agglayer.fullname" . }}
+                port:
+                  number: 2223
   defaultBackend:
     service:
       name: {{ include "agglayer.fullname" . }}

--- a/charts/agglayer/templates/service.yaml
+++ b/charts/agglayer/templates/service.yaml
@@ -5,12 +5,51 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agglayer.labels" . | nindent 4 }}
+  annotations:
+    cloud.google.com/backend-config: '{ "ports": {
+      "app-port": "app-backendconfig",
+      "metrics-port": "metrics-backendconfig"
+    }}'
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    - name: app-port
       protocol: TCP
-      name: http
+      port: 4444
+      targetPort: 4444
+    - name: metrics-port
+      protocol: TCP
+      port: 2223
+      targetPort: 2223
   selector:
     {{- include "agglayer.selectorLabels" . | nindent 4 }}
+
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: app-backendconfig
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 5
+    type: HTTP
+    requestPath: /health
+    port: 4444
+
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: metrics-backendconfig
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 5
+    type: HTTP
+    requestPath: /metrics
+    port: 2223


### PR DESCRIPTION
## Describe your changes
Expose the prometheus metrics endpoint via the ingress controller to allow viewing metrics while resolving the issue with Datadog metrics scraping

## Jira ticket number and link
SPEC-28

## Requirements

Mark the steps below as completed or `N/A` if not applicable. Leave blank if unsure or not done.

- [x] Version bumped in `Chart.yaml` for affected charts
- [ ] `README.md` has been updated or added to reflect the changes in this PR
- [x] I will delete my branch after merging my PR to maintain good repo hygiene
