### PR TITLE
ci(chart): use spaces to separate updated charts

### DIFF
--- a/.github/workflows/helm:publish.yaml
+++ b/.github/workflows/helm:publish.yaml
@@ -18,39 +18,40 @@ jobs:
   publish-chart:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Authenticate with GCP via OIDC
-      uses: google-github-actions/auth@v2
-      with:
-        token_format: access_token
-        workload_identity_provider: ${{ env.OIDC_PROVIDER }}
-        service_account: ${{ env.OIDC_SERVICE_ACCOUNT }}
+      - name: Authenticate with GCP via OIDC
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ env.OIDC_PROVIDER }}
+          service_account: ${{ env.OIDC_SERVICE_ACCOUNT }}
 
-    - name: Configure Artifact Registry authentication
-      run: |
-        echo '{"credHelpers": {"europe-west2-docker.pkg.dev": "gcloud"}}' > ~/.docker/config.json
+      - name: Configure Artifact Registry authentication
+        run: |
+          echo '{"credHelpers": {"europe-west2-docker.pkg.dev": "gcloud"}}' > ~/.docker/config.json
 
-    - name: Get list of modified charts
-      id: get-modified-charts
-      run: |
-        CHARTS=$(git diff --name-only HEAD^ HEAD \
-          | grep 'charts/.*/Chart.yaml' \
-          | xargs -I{} sh -c \
-            'if git diff HEAD^ HEAD {} | grep -q "version:"; then basename $(dirname {}); fi')
-        echo "Modified charts: $CHARTS"
-        echo "charts=$CHARTS" >> $GITHUB_OUTPUT
-    
-    - name: Push helm chart
-      if: steps.get-modified-charts.outputs.charts
-      env:
-        CHARTS: ${{ steps.get-modified-charts.outputs.charts }}
-      run: |
-        for chart in $CHARTS; do
-          echo "Processing chart $chart"
-          helm dependency update charts/$chart
-          helm package charts/$chart
-          helm push $chart*.tgz ${{ env.ARTIFACT_REGISTRY }}
-        done
+      - name: Get list of modified charts
+        id: get-modified-charts
+        run: |
+          CHARTS=$(git diff --name-only HEAD^ HEAD \
+            | grep 'charts/.*/Chart.yaml' \
+              | xargs -I{} sh -c \
+                'if git diff HEAD^ HEAD {} | grep -q "version:"; then basename $(dirname {}); fi' \
+              | tr '\n' ' ')
+          echo "Modified charts: $CHARTS"
+          echo "charts=$CHARTS" >> $GITHUB_OUTPUT
+
+      - name: Push helm chart
+        if: steps.get-modified-charts.outputs.charts
+        env:
+          CHARTS: ${{ steps.get-modified-charts.outputs.charts }}
+        run: |
+          for chart in $CHARTS; do
+            echo "Processing chart $chart"
+            helm dependency update charts/$chart
+            helm package charts/$chart
+            helm push $chart*.tgz ${{ env.ARTIFACT_REGISTRY }}
+          done

--- a/charts/cdk-executor/Chart.yaml
+++ b/charts/cdk-executor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk-rpc/Chart.yaml
+++ b/charts/cdk-rpc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk-synchronizer/Chart.yaml
+++ b/charts/cdk-synchronizer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This PR fixes the CI workflow that publishes the updated charts by using spaces instead of newline characters (issue happening when multiple charts are updated in the same PR)