### PR TITLE
fix: remove postgresql from new charts

### DIFF
--- a/charts/cdk-executor/Chart.yaml
+++ b/charts/cdk-executor/Chart.yaml
@@ -15,16 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v5.0.7"
-
-dependencies:
-  - name: postgresql
-    version: ~14.3.3
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled

--- a/charts/cdk-rpc/Chart.yaml
+++ b/charts/cdk-rpc/Chart.yaml
@@ -15,16 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.6.1"
-
-dependencies:
-  - name: postgresql
-    version: ~14.3.3
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled

--- a/charts/cdk-synchronizer/Chart.yaml
+++ b/charts/cdk-synchronizer/Chart.yaml
@@ -15,16 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.6.1"
-
-dependencies:
-  - name: postgresql
-    version: ~14.3.3
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled


### PR DESCRIPTION
This PR removes the dependency to postgresql in new separated cdk charts (the dependency is in helmfile directly).