### PR TITLE
SPEC-174: add service account permissions chart

### DIFF
--- a/charts/service-account-permissions/Chart.yaml
+++ b/charts/service-account-permissions/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: service-account-permissions
+description: A Helm chart for granting all permissions to the default service account of a namespace
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/charts/service-account-permissions/README.md
+++ b/charts/service-account-permissions/README.md
@@ -1,0 +1,7 @@
+# Service Account Permissions
+
+This chart deploys a ClusterRole and ClusterRoleBinding for granting all permissions to a service account.
+
+## Usage
+
+This chart is primarily used for self-hosted Github Actions runners deployed with Github's scaleset helm chart. It's needed because the service account created by Github doesn't have enough permissions to manage resources like secrets in other namespaces.

--- a/charts/service-account-permissions/templates/clusterrole.yaml
+++ b/charts/service-account-permissions/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ .Release.Name }}-cluster-role"
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]

--- a/charts/service-account-permissions/templates/clusterrolebinding.yaml
+++ b/charts/service-account-permissions/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-cluster-rolebinding"
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-cluster-role"
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/service-account-permissions/values.yaml
+++ b/charts/service-account-permissions/values.yaml
@@ -1,0 +1,2 @@
+serviceAccount:
+  name: some_name


### PR DESCRIPTION
This PR adds the `service-account-permissions` helm chart which deploys a ClusterRole and ClusterRoleBinding for granting all permissions to a service account.

This chart is primarily used for self-hosted Github Actions runners deployed with Github's scaleset helm chart. It's needed because the service account created by Github doesn't have enough permissions to manage resources like secrets in other namespaces.