### PR TITLE
SPEC-328: use tls cert from secret

### DIFF
--- a/charts/agglayer/Chart.yaml
+++ b/charts/agglayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/agglayer/templates/NOTES.txt
+++ b/charts/agglayer/templates/NOTES.txt
@@ -1,7 +1,0 @@
-export INGRESS=$(kubectl get ingress --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].metadata.name}")
-export IP_ADDRESS=$(kubectl get ingress $INGRESS --namespace {{ .Release.Namespace }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-1. Almost there, homey. Make sure you add a DNS A record for {{ .Values.domain }} pointing to your IP address $IP_ADDRESS.
-It may take a few minutes for the IP address to be available.
-
-If you get tired of waiting, you can always check for it later with kubectl get ingress $INGRESS --namespace {{ .Release.Namespace }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}"
-but remember, your ManagedCertificate will not be provisioned by GCP until you create the DNS A record in Cloudflare.

--- a/charts/agglayer/templates/certificate.yaml
+++ b/charts/agglayer/templates/certificate.yaml
@@ -1,8 +1,9 @@
-apiVersion: networking.gke.io/v1
-kind: ManagedCertificate
+apiVersion: v1
+kind: Secret
 metadata:
-  name: managed-cert
+  name: {{ include "agglayer.fullname" . }}-cloudflare-origin-cert
   namespace: {{ .Release.Namespace }}
-spec:
-  domains:
-  - {{ .Values.domain }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.tls.base64Cert }}
+  tls.key: {{ .Values.tls.base64Key }}

--- a/charts/agglayer/templates/ingress.yaml
+++ b/charts/agglayer/templates/ingress.yaml
@@ -8,10 +8,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    networking.gke.io/managed-certificates: managed-cert
     ingressClassName: "gce"
     ingress.kubernetes.io/healthcheck-path: "/metrics"
 spec:
+  tls:
+    - hosts:
+      - {{ .Values.domain }}
+      secretName: {{ include "agglayer.fullname" . }}-cloudflare-origin-cert
   rules:
     - http:
         paths:

--- a/charts/agglayer/values.yaml
+++ b/charts/agglayer/values.yaml
@@ -16,6 +16,10 @@ ports:
 
 domain: agglayer-test.polygon.technology
 
+tls:
+  base64Cert: ""
+  base64Key: ""
+
 command: agglayer run --cfg /etc/agglayer/config.toml
 
 fullNodeRPCs:


### PR DESCRIPTION
This PR updates the `agglayer` to replace the use of GCP `ManagedCertificate` with `*polygon.technology` Cloudflare Origin certificates, stored as k8s secret. This allows us to use Cloudflare Proxy security feature on the DNS records.