### PR TITLE
SPEC-379: replace erigon.yaml by secret

### DIFF
--- a/charts/cdk-erigon/Chart.yaml
+++ b/charts/cdk-erigon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk-erigon/templates/configmap.yaml
+++ b/charts/cdk-erigon/templates/configmap.yaml
@@ -3,8 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "cdk-erigon.fullname" . }}
 data:
-  erigon.yaml: |-
-{{ .Values.config | indent 4 }}
   dynamic-integration-allocs.json: |-
 {{ .Values.dynamicIntegrationAllocs | indent 4 }}
   dynamic-integration-chainspec.json: |-

--- a/charts/cdk-erigon/templates/statefulset.yaml
+++ b/charts/cdk-erigon/templates/statefulset.yaml
@@ -96,19 +96,21 @@ spec:
       {{- end }}
       volumes:
         - name: cdk-erigon-config
-          configMap:
-            name: {{ include "cdk-erigon.fullname" . }}
-            items:
-            - key: "erigon.yaml"
-              path: "erigon.yaml"
-            - key: "dynamic-integration-allocs.json"
-              path: "dynamic-integration-allocs.json"
-            - key: "dynamic-integration-chainspec.json"
-              path: "dynamic-integration-chainspec.json"
-            - key: "dynamic-integration-chainspec.json"
-              path: "{{ .Values.chainName }}-chainspec.json"
-            - key: "dynamic-integration-conf.json"
-              path: "dynamic-integration-conf.json"
+          projected:
+            sources:
+            - configMap:
+                name: {{ include "cdk-erigon.fullname" . }}
+                items:
+                  - key: "dynamic-integration-allocs.json"
+                    path: "dynamic-integration-allocs.json"
+                  - key: "dynamic-integration-chainspec.json"
+                    path: "dynamic-integration-chainspec.json"
+                  - key: "dynamic-integration-chainspec.json"
+                    path: "{{ .Values.chainName }}-chainspec.json"
+                  - key: "dynamic-integration-conf.json"
+                    path: "dynamic-integration-conf.json"
+            - secret:
+                name: {{ .Values.existingSecret }}
   volumeClaimTemplates:
     - metadata:
         name: datadir

--- a/charts/cdk-erigon/values.yaml
+++ b/charts/cdk-erigon/values.yaml
@@ -44,7 +44,7 @@ is_sequencer: 0
 
 # cdk-erigon config file
 # ref: https://github.com/0xPolygonHermez/cdk-erigon?tab=readme-ov-file#config
-config: ""
+existingSecret: "secretName"
 
 # cdk-erigon dynamic configuration
 # ref: https://github.com/0xPolygonHermez/cdk-erigon?tab=readme-ov-file#dynamic-chain-configuration


### PR DESCRIPTION
## Describe your changes
Instead of taking in the `erigon.yaml` config file as a value, use the `existingSecret` parameter.
This can be combined with the [op-secrets](https://github.com/0xPolygon/helm-charts/tree/main/charts/op-secrets) chart.

## Jira ticket number and link
[SPEC-379](https://polygon.atlassian.net/browse/SPEC-379)

Mark the steps below as completed or `N/A` if not applicable. Leave blank if unsure or not done.

- [x] Version bumped in `Chart.yaml` for affected charts
- [x] `README.md` has been updated or added to reflect the changes in this PR
- [x] I will delete my branch after merging my PR to maintain good repo hygiene


[SPEC-379]: https://polygon.atlassian.net/browse/SPEC-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ