### PR TITLE
SPEC-494: add internal ingresses

### DIFF
--- a/charts/bridge-ui/Chart.yaml
+++ b/charts/bridge-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge-ui/templates/ingress.yaml
+++ b/charts/bridge-ui/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "bridgeUI.fullname" . }}
+  annotations:
+    cert-manager.io/issuer: gcp-cas-issuer
+    cert-manager.io/issuer-kind: GoogleCASClusterIssuer
+    cert-manager.io/issuer-group: cas-issuer.jetstack.io
+    kubernetes.io/ingress.class: "gce-internal"
+    # Since no static ip address is provided, only https can be used as
+    # protocol for the GCP-managed load balancer
+    # See https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#https_between_client_and_load_balancer
+    kubernetes.io/ingress.allow-http: "false"
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.hostname }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: "{{ .Values.ingress.hostname }}-secret-tls"
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "bridgeUI.fullname" . }}
+                port:
+                  name: app-port

--- a/charts/bridge-ui/values.yaml
+++ b/charts/bridge-ui/values.yaml
@@ -32,6 +32,9 @@ container:
     polygonZkEvmRpcUrl: "http://cdk-erigon-rpc:8123"
     zkEvmNetworkConfigPolygonZkEvmGlobalExitRootAddress: ""
 
+ingress:
+  hostname: something.dev.polygon
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/bridge/Chart.yaml
+++ b/charts/bridge/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge/templates/ingress.yaml
+++ b/charts/bridge/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "bridge.fullname" . }}
+  annotations:
+    cert-manager.io/issuer: gcp-cas-issuer
+    cert-manager.io/issuer-kind: GoogleCASClusterIssuer
+    cert-manager.io/issuer-group: cas-issuer.jetstack.io
+    kubernetes.io/ingress.class: "gce-internal"
+    # Since no static ip address is provided, only https can be used as
+    # protocol for the GCP-managed load balancer
+    # See https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#https_between_client_and_load_balancer
+    kubernetes.io/ingress.allow-http: "false"
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.hostname }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: "{{ .Values.ingress.hostname }}-secret-tls"
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "bridge.fullname" . }}
+                port:
+                  name: http

--- a/charts/bridge/values.yaml
+++ b/charts/bridge/values.yaml
@@ -18,6 +18,9 @@ service:
   type: ClusterIP
   port: 8080
 
+ingress:
+  hostname: something.dev.polygon
+
 resources:
   limits:
     memory: 1G

--- a/charts/cdk-erigon/Chart.yaml
+++ b/charts/cdk-erigon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk-erigon/templates/ingress.yaml
+++ b/charts/cdk-erigon/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cdk-erigon.fullname" . }}
+  annotations:
+    cert-manager.io/issuer: gcp-cas-issuer
+    cert-manager.io/issuer-kind: GoogleCASClusterIssuer
+    cert-manager.io/issuer-group: cas-issuer.jetstack.io
+    kubernetes.io/ingress.class: "gce-internal"
+    # Since no static ip address is provided, only https can be used as
+    # protocol for the GCP-managed load balancer
+    # See https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balance-ingress#https_between_client_and_load_balancer
+    kubernetes.io/ingress.allow-http: "false"
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.ingress.hostname }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: "{{ .Values.ingress.hostname }}-secret-tls"
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "cdk-erigon.fullname" . }}
+                port:
+                  name: rpc

--- a/charts/cdk-erigon/values.yaml
+++ b/charts/cdk-erigon/values.yaml
@@ -23,6 +23,9 @@ service:
   metrics:
     port: 9090
 
+ingress:
+  hostname: something.dev.polygon
+
 resources:
   limits:
     memory: 10Gi


### PR DESCRIPTION
This PR adds a `gce-internal` ingress to some components, to expose them publicly (for users connected to Cloudflare Zero Trust)