### PR TITLE
SPEC-685: disable exchange rates

### DIFF
--- a/charts/zkevm-explorer/Chart.yaml
+++ b/charts/zkevm-explorer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zkevm-explorer/templates/statefulset.yaml
+++ b/charts/zkevm-explorer/templates/statefulset.yaml
@@ -89,5 +89,7 @@ spec:
               value: "false"
             - name: DISABLE_INDEXER
               value: "false"
+            - name: DISABLE_EXCHANGE_RATES
+              value: "true"
             - name: INDEXER_ZKEVM_BATCHES_ENABLED
               value: "true"


### PR DESCRIPTION
This PR disables blockscout's exchange rates feature in the zkevm-explorer chart. This will remove a bunch of warning logs.