### PR TITLE
SPEC-802: use FinalizedBlock for finality

### DIFF
--- a/charts/cdk/Chart.yaml
+++ b/charts/cdk/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk/templates/configmap.yaml
+++ b/charts/cdk/templates/configmap.yaml
@@ -52,11 +52,16 @@ data:
     [L2Config]
     GlobalExitRootAddr = {{ .Values.config.l2.globalExitRootAddress | quote }}
 
+    [BridgeL1Sync]
+    BlockFinality="FinalizedBlock"
+
     [BridgeL2Sync]
     OriginNetwork={{ .Values.config.l2.rollupId | int }}
+    BlockFinality="FinalizedBlock"
 
     [L1InfoTreeSync]
     SyncBlockChunkSize={{ .Values.config.l1.syncBlockChunkSize | int }}
+    BlockFinality="FinalizedBlock"
 
     [Log]
     Environment = {{ .Values.config.log.environment | quote }}
@@ -68,5 +73,6 @@ data:
     CheckSettledInterval = {{ .Values.config.aggSender.checkSettledInterval | quote }}
     MaxCertSize = {{ .Values.config.aggSender.maxCertSize | int }}
     SaveCertificatesToFilesPath = {{ .Values.config.aggSender.saveCertificatesToFilesPath | quote }}
+    BlockFinality="FinalizedBlock"
   genesis.json: |-
 {{ .Values.genesis | indent 4 }}


### PR DESCRIPTION
This PR updates the `cdk` chart to specify `FinalizedBlock` as syncers's `BlockFinality` .