### PR TITLE
SPEC-838: remove FinalizedBlock in cdk chart

### DIFF
--- a/charts/cdk/Chart.yaml
+++ b/charts/cdk/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk/templates/configmap.yaml
+++ b/charts/cdk/templates/configmap.yaml
@@ -57,7 +57,6 @@ data:
 
     [BridgeL2Sync]
     OriginNetwork={{ .Values.config.l2.rollupId | int }}
-    BlockFinality="FinalizedBlock"
 
     [L1InfoTreeSync]
     SyncBlockChunkSize={{ .Values.config.l1.syncBlockChunkSize | int }}


### PR DESCRIPTION
This PR removes `BlockFinality: FinalizedBlock` from the `BridgeL2Syncer` in the `cdk` chart. The rationale is that cdk-erigon doesn't return finalized blocks.