### PR TITLE
SPEC-855: add missing agglayer-prover labels

### DIFF
--- a/charts/agglayer-prover/Chart.yaml
+++ b/charts/agglayer-prover/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/agglayer-prover/templates/_helpers.tpl
+++ b/charts/agglayer-prover/templates/_helpers.tpl
@@ -40,6 +40,17 @@ helm.sh/chart: {{ include "agglayerProver.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+name: {{ include "agglayerProver.fullname" . }}
+host: gcp
+location: {{ default "unspecified" .Values.region }}
+env: {{ .Values.env }}
+role: application
+team: agglayer
+p_service: agglayer-prover
+tag: v3
+tags.datadoghq.com/env: {{ .Values.env }}
+tags.datadoghq.com/name: {{ include "agglayerProver.fullname" . }}
+deployment: {{ htmlDateInZone (now) "UTC" }}
 {{- end }}
 
 {{/*

--- a/charts/agglayer/Chart.yaml
+++ b/charts/agglayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.12.0
+version: 2.12.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/agglayer/templates/_helpers.tpl
+++ b/charts/agglayer/templates/_helpers.tpl
@@ -45,7 +45,7 @@ host: gcp
 location: {{ default "unspecified" .Values.region }}
 env: {{ .Values.env }}
 role: application
-team: cdk
+team: agglayer
 p_service: agglayer
 tag: v3
 tags.datadoghq.com/env: {{ .Values.env }}


### PR DESCRIPTION
This PR adds missing labels to the agglayer-prover statefulset. It also fixes the `team` label in the agglayer statefulset labels.