### PR TITLE
SPEC-862: use bridge-tester annotations on job

### DIFF
--- a/charts/bridge-tester/Chart.yaml
+++ b/charts/bridge-tester/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge-tester/templates/job.yaml
+++ b/charts/bridge-tester/templates/job.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   schedule: {{ .Values.schedule | quote }}
   jobTemplate:
+    metadata:
+      labels:
+        {{- include "bridgeTester.labels" . | nindent 4 }}
     spec:
       template:
         spec:


### PR DESCRIPTION
This PR fixes the job template of the bridge-tester chart by adding the annotations set to the cronjob.