### PR TITLE
fix: move job labels again

### DIFF
--- a/charts/bridge-tester/Chart.yaml
+++ b/charts/bridge-tester/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge-tester/templates/job.yaml
+++ b/charts/bridge-tester/templates/job.yaml
@@ -9,12 +9,12 @@ metadata:
     {{- include "bridgeTester.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.schedule | quote }}
-  jobTemplate:
-    metadata:
-      labels:
-        {{- include "bridgeTester.labels" . | nindent 8 }}
+  jobTemplate:    
     spec:
       template:
+        metadata:
+          labels:
+            {{- include "bridgeTester.labels" . | nindent 12 }}
         spec:
           containers:
             - name: script-runner


### PR DESCRIPTION
This PR moves bridge-tester job labels to the right place.