### PR TITLE
fix: use service tag

### DIFF
--- a/charts/bridge-tester/Chart.yaml
+++ b/charts/bridge-tester/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge-tester/templates/_helpers.tpl
+++ b/charts/bridge-tester/templates/_helpers.tpl
@@ -49,6 +49,7 @@ p_service: bridge-tester
 tag: v3
 tags.datadoghq.com/env: {{ .Values.env }}
 tags.datadoghq.com/name: {{ include "bridgeTester.fullname" . }}
+tags.datadoghq.com/service: {{ include "bridgeTester.fullname" . }}
 deployment: {{ htmlDateInZone (now) "UTC" }}
 {{- end }}
 


### PR DESCRIPTION
This PR fixes the datadog labels for bridge-tester by using the `service` tag.