### PR TITLE
SPEC-890: update bridge

### DIFF
--- a/charts/bridge/Chart.yaml
+++ b/charts/bridge/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge/templates/configmap.yaml
+++ b/charts/bridge/templates/configmap.yaml
@@ -94,7 +94,7 @@ data:
     PolygonZkEVMAddress = {{ .Values.config.network.polygonZkEVMAddress | quote }}
     L2PolygonBridgeAddresses = [{{ .Values.config.network.l2PolygonBridgeAddress | quote }}]
     L2PolygonZkEVMGlobalExitRootAddresses = [{{ .Values.config.network.l2PolygonZkEVMGlobalExitRootAddress | quote }}]
-    SovereignChains = [{{ .Values.config.network.isSovereignChain }}]
+    RequireSovereignChainSmcs = [{{ .Values.config.network.requireSovereignChainSmcs }}]
 
     [ClaimTxManager]
     FrequencyToMonitorTxs = "5s"

--- a/charts/bridge/values.yaml
+++ b/charts/bridge/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 image:
   repository: hermeznetwork/zkevm-bridge-service
   pullPolicy: IfNotPresent
-  tag: "v0.6.0-RC6"
+  tag: "v0.6.0-RC7"
   command: ["/app/zkevm-bridge"]
   args: ["run", "--cfg", "/etc/bridge/bridge-config.toml"]
 
@@ -44,7 +44,7 @@ config:
     polygonZkEVMAddress: "0x0000000000000000000000000000000000000000"
     l2PolygonBridgeAddress: "0x0000000000000000000000000000000000000000"
     l2PolygonZkEVMGlobalExitRootAddress: "0x0000000000000000000000000000000000000000"
-    isSovereignChain: true
+    requireSovereignChainSmcs: true
 
 existingSecret: "secretName"
 secretItem:


### PR DESCRIPTION
This PR updates the bridge chart with the newly renamed `RequireSovereignChainSmcs` config field. 