### PR TITLE
fix: add missing BlockFinality bridge config field

### DIFF
--- a/charts/bridge/Chart.yaml
+++ b/charts/bridge/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge/templates/configmap.yaml
+++ b/charts/bridge/templates/configmap.yaml
@@ -64,6 +64,7 @@ data:
     L2URLs = [{{ .Values.config.etherman.l2Url | quote }}]
 
     [Synchronizer]
+    BlockFinality = "FinalizedBlock"
     SyncInterval = "5s"
     SyncChunkSize = 1000
 


### PR DESCRIPTION
This PR adds the missing BlockFinality config field to the bridge chart.