### PR TITLE
fix: use stable image of foundry-rs

### DIFF
--- a/charts/bridge-tester/Chart.yaml
+++ b/charts/bridge-tester/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bridge-tester/templates/job.yaml
+++ b/charts/bridge-tester/templates/job.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           containers:
             - name: script-runner
-              image: ghcr.io/foundry-rs/foundry:latest
+              image: ghcr.io/foundry-rs/foundry:stable
               command: ["/bin/bash"]
               args:
                 - -c


### PR DESCRIPTION
This PR updates the `bridge-tester` chart to use the `stable` image of foundry-rs instead of `latest`.