### PR TITLE
fix: add missing datadog service label on agglayer

### DIFF
--- a/charts/agglayer/Chart.yaml
+++ b/charts/agglayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.13.0
+version: 2.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/agglayer/templates/_helpers.tpl
+++ b/charts/agglayer/templates/_helpers.tpl
@@ -50,6 +50,7 @@ p_service: agglayer
 tag: v3
 tags.datadoghq.com/env: {{ .Values.env }}
 tags.datadoghq.com/name: {{ include "agglayer.fullname" . }}
+tags.datadoghq.com/service: {{ include "agglayer.fullname" . }}
 deployment: {{ htmlDateInZone (now) "UTC" }}
 {{- end }}
 


### PR DESCRIPTION
This PR adds the missing datadog `service` label to `agglayer` resources.