### PR TITLE
SPEC-1152: rework datadog tags from annotations

### DIFF
--- a/charts/cdk-erigon/Chart.yaml
+++ b/charts/cdk-erigon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk-erigon/templates/_helpers.tpl
+++ b/charts/cdk-erigon/templates/_helpers.tpl
@@ -40,14 +40,9 @@ helm.sh/chart: {{ include "cdk-erigon.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-name: {{ .Values.tags.name }}
-role: {{ .Values.tags.role }}
-env: {{ .Values.tags.env }}
-team: {{ .Values.tags.team }}
-partner: {{ .Values.tags.partner }}
-tags.datadoghq.com/env: {{ .Values.tags.env }}
-tags.datadoghq.com/name: {{ include "cdk-erigon.fullname" . }}
-tags.datadoghq.com/service: {{ include "cdk-erigon.fullname" . }}
+tags.datadoghq.com/env: {{ .Values.env }}
+tags.datadoghq.com/service: cdk-erigon
+tags.datadoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/charts/cdk-erigon/values.yaml
+++ b/charts/cdk-erigon/values.yaml
@@ -1,10 +1,11 @@
-# Tags for identifying/tracking resources
-tags:
-  name: bali-XX
-  env: bali
-  role: rpc
-  team: cdk
-  partner: polygon # polygon or network name
+env: bali
+
+podAnnotations:
+  # name: Internal name of the network (e.g., bali-01)
+  # role: permissionless node, rpc, sequencer
+  # partner: polygon or IP (Implementation Provider)
+  # network: network name (e.g., katana)
+  ad.datadoghq.com/tags: '{"name": "myname","role": "myrole","partner": "polygon","network": "mynetwork"}'
 
 # General config
 replicaCount: 1

--- a/charts/permissionless-nodes/Chart.yaml
+++ b/charts/permissionless-nodes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/charts/executor/templates/deployment.yaml
+++ b/charts/permissionless-nodes/charts/executor/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       {{- include "executor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.global.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/permissionless-nodes/charts/rpc/templates/deployment.yaml
+++ b/charts/permissionless-nodes/charts/rpc/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
               ]
             }
           ]
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "rpc.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/charts/permissionless-nodes/charts/synchronizer/templates/deployment.yaml
+++ b/charts/permissionless-nodes/charts/synchronizer/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
               ]
             }
           ]
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "synchronizer.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/charts/permissionless-nodes/values.yaml
+++ b/charts/permissionless-nodes/values.yaml
@@ -9,6 +9,13 @@ global:
   p_service: cdk
   partner: polygon
   tag: v3
+  podAnnotations:
+    # name: Internal name of the network (e.g., bali-01)
+    # role: permissionless node, rpc, sequencer
+    # partner: polygon or IP (Implementation Provider)
+    # network: network name (e.g., katana)
+    ad.datadoghq.com/tags: '{"name": "myname","role": "myrole","partner": "polygon","network": "mynetwork"}'
+
 
 jumphost:
   # We only enable this in non-production environments, right? RIGHT?!?!?


### PR DESCRIPTION
This PR follows #140 and reworks the whole datadog tags approach to use pod annotations instead.