### PR TITLE
SPEC-1152: add project tag to cdk-erigon and permissionless node charts

### DIFF
--- a/charts/cdk-erigon/Chart.yaml
+++ b/charts/cdk-erigon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cdk-erigon/values.yaml
+++ b/charts/cdk-erigon/values.yaml
@@ -1,11 +1,12 @@
 env: bali
 
 podAnnotations:
-  # name: Internal name of the network (e.g., bali-01)
+  # name: internal name of the network (e.g., bali-01)
+  # project: agglayer
   # role: permissionless node, rpc, sequencer
   # partner: polygon or IP (Implementation Provider)
   # network: network name (e.g., katana)
-  ad.datadoghq.com/tags: '{"name": "myname","role": "myrole","partner": "polygon","network": "mynetwork"}'
+  ad.datadoghq.com/tags: '{"name": "myname","project": "agglayer", "role": "myrole","partner": "polygon","network": "mynetwork"}'
 
 # General config
 replicaCount: 1

--- a/charts/permissionless-nodes/Chart.yaml
+++ b/charts/permissionless-nodes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/permissionless-nodes/charts/executor/templates/_helpers.tpl
+++ b/charts/permissionless-nodes/charts/executor/templates/_helpers.tpl
@@ -49,6 +49,9 @@ team: {{ .Values.global.team }}
 p_service: {{ .Values.global.p_service }}
 partner: {{ .Values.global.partner }}
 tag: {{ .Values.global.tag }}
+tags.datadoghq.com/env: {{ .Values.global.env }}
+tags.datadoghq.com/service: zkevm-prover
+tags.datadoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/charts/permissionless-nodes/charts/rpc/templates/_helpers.tpl
+++ b/charts/permissionless-nodes/charts/rpc/templates/_helpers.tpl
@@ -49,6 +49,9 @@ team: {{ .Values.global.team }}
 p_service: {{ .Values.global.p_service }}
 partner: {{ .Values.global.partner }}
 tag: {{ .Values.global.tag }}
+tags.datadoghq.com/env: {{ .Values.global.env }}
+tags.datadoghq.com/service: cdk-validium-node
+tags.datadoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/charts/permissionless-nodes/charts/synchronizer/templates/_helpers.tpl
+++ b/charts/permissionless-nodes/charts/synchronizer/templates/_helpers.tpl
@@ -49,6 +49,9 @@ team: {{ .Values.global.team }}
 p_service: {{ .Values.global.p_service }}
 partner: {{ .Values.global.partner }}
 tag: {{ .Values.global.tag }}
+tags.datadoghq.com/env: {{ .Values.global.env }}
+tags.datadoghq.com/service: cdk-validium-node
+tags.datadoghq.com/version: {{ .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/charts/permissionless-nodes/values.yaml
+++ b/charts/permissionless-nodes/values.yaml
@@ -10,11 +10,12 @@ global:
   partner: polygon
   tag: v3
   podAnnotations:
-    # name: Internal name of the network (e.g., bali-01)
+    # name: internal name of the network (e.g., bali-01)
+    # project: agglayer
     # role: permissionless node, rpc, sequencer
     # partner: polygon or IP (Implementation Provider)
     # network: network name (e.g., katana)
-    ad.datadoghq.com/tags: '{"name": "myname","role": "myrole","partner": "polygon","network": "mynetwork"}'
+    ad.datadoghq.com/tags: '{"name": "myname","project": "agglayer", "role": "myrole","partner": "polygon","network": "mynetwork"}'
 
 
 jumphost:


### PR DESCRIPTION
This PR follows #141 and adds one new `project` tag.