### PR TITLE
SPEC-1185: add aggkit networkid config field

### DIFF
--- a/charts/aggkit/Chart.yaml
+++ b/charts/aggkit/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/aggkit/templates/configmap.yaml
+++ b/charts/aggkit/templates/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   config.toml: |
+    NetworkID = {{ .Values.config.l2.rollupId | int }}
     PathRWData = {{ .Values.storage.path | quote }}
     L1URL = {{ index $opSecrets.data "l1RpcURL" | b64dec | quote }}
     L2URL = {{ .Values.config.l2.rpcURL | quote }}


### PR DESCRIPTION
This PR adds a `networkID` config field in the aggkit chart.