### PR TITLE
fix: remove conflicting labels from helper

### DIFF
--- a/charts/blockscout/Chart.yaml
+++ b/charts/blockscout/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/blockscout/templates/_helpers.tpl
+++ b/charts/blockscout/templates/_helpers.tpl
@@ -35,20 +35,11 @@ Common labels
 */}}
 {{- define "blockscout.labels" -}}
 helm.sh/chart: {{ include "blockscout.chart" . }}
-{{ include "blockscout.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 tags.datadoghq.com/env: {{ .Values.env }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "blockscout.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "blockscout.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This PR follows #151 and removes conflicting pod labels set from the helper file.