### PR TITLE
feat(aggkit): expose service config

### DIFF
--- a/charts/aggkit/Chart.yaml
+++ b/charts/aggkit/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/aggkit/templates/service.yaml
+++ b/charts/aggkit/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "aggkit.labels" . | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.container.ports.aggsender }}
       targetPort: aggsender
@@ -15,5 +15,8 @@ spec:
       targetPort: bridge
       protocol: TCP
       name: bridge
+  # StatefulSets require headless services
+  # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations
+  clusterIP: {{ .Values.service.clusterIP }}
   selector:
     {{- include "aggkit.selectorLabels" . | nindent 4 }}

--- a/charts/aggkit/values.yaml
+++ b/charts/aggkit/values.yaml
@@ -19,6 +19,10 @@ container:
     aggsender: 5576
     bridge: 5577
 
+service:
+  type: ClusterIP
+  clusterIP: None
+
 ingresses:
   hostnames:
     aggkit: something.dev.polygon


### PR DESCRIPTION
This PR exposes the config of the k8s service in the aggkit chart to allow for different types of services.