### PR TITLE
feat(agglayer): add gce ingress for agglayer gateway

### DIFF
--- a/charts/agglayer/Chart.yaml
+++ b/charts/agglayer/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.1
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0-rc.22"
+appVersion: "0.3.3"

--- a/charts/agglayer/templates/ingress.yaml
+++ b/charts/agglayer/templates/ingress.yaml
@@ -92,3 +92,37 @@ spec:
                 name: {{ include "agglayer.fullname" . }}-grpc
                 port:
                   number: 443
+---
+# gRPC API through the new gateway/proxy
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agglayer.name" . }}-gateway-ingress
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    ingressClassName: "gce"
+spec:
+  tls:
+    - hosts:
+      - gateway-{{ .Values.domain }}
+      secretName: {{ include "agglayer.fullname" . }}-cloudflare-origin-cert
+  rules:
+    - host: gateway-{{ .Values.domain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agglayer.fullname" . }}-gateway
+                port:
+                  number: {{ .Values.ports.grpc }}
+  defaultBackend:
+    service:
+      name: {{ include "agglayer.fullname" . }}-gateway
+      port:
+        number: {{ .Values.ports.grpc }}

--- a/charts/agglayer/templates/service.yaml
+++ b/charts/agglayer/templates/service.yaml
@@ -26,6 +26,7 @@ spec:
     {{- include "agglayer.selectorLabels" . | nindent 4 }}
 
 ---
+# this will be replaced by *-gateway soon
 apiVersion: v1
 kind: Service
 metadata:
@@ -44,6 +45,29 @@ spec:
       protocol: TCP
       port: 443
       targetPort: {{ .Values.ports.grpc }}
+  selector:
+    {{- include "agglayer.selectorLabels" . | nindent 4 }}
+---
+# this will replace *-grpc soon
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agglayer.fullname" . }}-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agglayer.labels" . | nindent 4 }}
+  annotations:
+    cloud.google.com/backend-config: '{ "ports": {
+      "grpc": "gateway-backendconfig"
+    }}'
+    cloud.google.com/neg: '{"ingress": true}'
+spec:
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: {{ .Values.ports.grpc }}
+      targetPort: {{ .Values.ports.grpc }}
+      appProtocol: kubernetes.io/h2c
   selector:
     {{- include "agglayer.selectorLabels" . | nindent 4 }}
 ---
@@ -93,3 +117,19 @@ spec:
     type: HTTP
     requestPath: /health
     port: {{ .Values.ports.readrpc }}
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: gateway-backendconfig
+spec:
+  healthCheck:
+    checkIntervalSec: 30
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 5
+    type: HTTP
+    requestPath: /health
+    port: {{ .Values.ports.readrpc }}
+  securityPolicy:
+    name: {{ .Values.securityPolicy }}

--- a/charts/agglayer/values.yaml
+++ b/charts/agglayer/values.yaml
@@ -9,7 +9,9 @@ podLabels:
 image:
   repository: ghcr.io/agglayer/agglayer
   pullPolicy: IfNotPresent
-  tag: 0.3.0-rc.22
+  tag: 0.3.3
+
+securityPolicy: "security-policy"
 
 ports:
   grpc: 9089


### PR DESCRIPTION
## Describe your changes
Add new ingress backed by gce controller:
- now h2c is supported, nginx can be replaced
- by using gce, we can use security policies from cloud armor

In summary, this PR creates a new set of ingress + service + backendconfig to expose the grpc endpoint of the agglayer using the gce ingress controller.

Additionally we can use security policies to limit inbound traffic.

## Jira ticket number and link

## Requirements

Mark the steps below as completed or `N/A` if not applicable. Leave blank if unsure or not done.

- [x] Version bumped in `Chart.yaml` for affected charts
- [ ] `README.md` has been updated or added to reflect the changes in this PR
- [x] I will delete my branch after merging my PR to maintain good repo hygiene
