### PR TITLE
chore(codeowners): use agglayer org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @0xPolygon/agglayer-infra
+* @agglayer/agglayer-infra


### PR DESCRIPTION
This PR updates the CODEOWNERS to set the agglayer-infra team from the agglayer org as owner (following the repo migration to the agglayer org).