### PR TITLE
fix: add bitnami repo to fix the packaging of pless chart

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -35,6 +35,11 @@ jobs:
         with:
           version: v3.14.4
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:

--- a/.github/workflows/release-existing-charts.yaml
+++ b/.github/workflows/release-existing-charts.yaml
@@ -49,6 +49,10 @@ jobs:
           CR_CHARTS_DIR: charts
           CR_SKIP_EXISTING: true
         run: |
+          # Add required Helm repositories
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
+
           # Create .cr-release-packages directory
           mkdir -p .cr-release-packages
 


### PR DESCRIPTION
This is a fix we need when packaging the `permissionless-node` chart. It's the only chart with a dependency (postgres) whose repo must be added manually (supposedly).