### PR TITLE
feat(aggkit-prover): add config to set the op-succinct vkeys

### DIFF
--- a/charts/aggkit-prover/Chart.yaml
+++ b/charts/aggkit-prover/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-rc.6"
+appVersion: "2.1.0"

--- a/charts/aggkit-prover/templates/configmap.yaml
+++ b/charts/aggkit-prover/templates/configmap.yaml
@@ -64,6 +64,17 @@ data:
     sp1-cluster-endpoint = {{ $sp1NetworkRpcURL | quote }}
     request-timeout = 3600
     proving-timeout = 3600
+    {{- if or .Values.config.opSuccinct.aggregationVkey .Values.config.opSuccinct.rangeVkeyCommitment }}
+
+    # Optional override of the op-succinct vkeys embedded in the aggkit-prover image.
+    [aggchain-proof-service.op-succinct]
+    {{- if .Values.config.opSuccinct.aggregationVkey }}
+    aggregation-vkey = {{ .Values.config.opSuccinct.aggregationVkey | quote }}
+    {{- end }}
+    {{- if .Values.config.opSuccinct.rangeVkeyCommitment }}
+    range-vkey-commitment = {{ .Values.config.opSuccinct.rangeVkeyCommitment | quote }}
+    {{- end }}
+    {{- end }}
 
     [primary-prover.network-prover]
     proving-timeout = "1h"

--- a/charts/aggkit-prover/values.yaml
+++ b/charts/aggkit-prover/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/agglayer/aggkit-prover
   pullPolicy: IfNotPresent
-  tag: "2.0.0-rc.6"
+  tag: "2.1.0"
   command: ["/usr/local/bin/aggkit-prover"]
   args: ["run", "--config-path", "/etc/aggkit/aggkit-prover-config.toml"]
 
@@ -31,6 +31,19 @@ config:
   polygonRollupManager: "0x0000000000000000000000000000000000000000"
   globalExitRootManagerV2SovereignChain: "0x0000000000000000000000000000000000000000"
   proposerEndpoint: "http://op-succinct-proposer:50001"
+  # Optional override of the op-succinct verification keys embedded in the
+  # aggkit-prover image at build time (from op-succinct-elfs). Setting these
+  # lets an op-succinct upgrade be rolled out by config change only, without a
+  # new aggkit-prover release/image. When both are left empty, the embedded
+  # values are used and the [aggchain-proof-service.op-succinct] section is
+  # omitted from the config. Each value is independent.
+  # Generate them with the aggkit-prover CLI:
+  #   aggkit-prover op-succinct-vkey --elf-dir /path/to/elf/directory/
+  opSuccinct:
+    # Bincode-serialized aggregation SP1VerifyingKey, hex-encoded (0x-prefixed).
+    aggregationVkey: ""
+    # Range vkey commitment, hex-encoded 32 bytes (0x-prefixed).
+    rangeVkeyCommitment: ""
   genesis: |
     {}
 


### PR DESCRIPTION
Follows https://github.com/agglayer/provers/pull/358

Available from [aggkit-prover v2.1.0](https://github.com/agglayer/provers/releases/tag/v2.1.0)

## Example

With [op-succinct v3.11.0-agglayer](https://github.com/agglayer/op-succinct/releases/tag/v3.11.0-agglayer), aggkit-prover needs to have this in its config:

```toml
[aggchain-proof-service.op-succinct]
aggregation-vkey = "0x00001f3000007804000000005aaf5c6158eef23b1e13c5dd543137d56ea1d2d92bb7e1156e5f8771503e8d2b78ff16631d97f27c7c04880d228440d323a65e49040a1cc0143aaf5f5ad4237d01d26385287ca799524611c4338f4ac3645b1a1a1483d29b00000000"
range-vkey-commitment = "0x6e84074e62b4125b26f4d2201843356379b0363466c03d215fff9ff43cf811ae"
# aggregation on-chain vkey hash (bytes32): 0x0035e8f05f8791f13911803b76f71bffd23bda68a28f614d0acc7589d587b9c6
```